### PR TITLE
Update README and add manual configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@
 This repository contains a script that allows you to create a tunnel to your private website for cloud testing in Qase. It uses the FRP client to create a tunnel to your private website. The script creates a configuration file for the FRP client and runs it. The script is written in bash and can be run on any platform that supports bash.
 
 ## Usage
-You can run the script with the following command on MacOS or Linux:
-```bash
+
+Initial preparation:
+
+```shell
 wget -O frp.sh https://raw.githubusercontent.com/qase-tms/qase-frp/refs/heads/main/frp.sh && chmod +x frp.sh
+```
+
+After the installation, you can run the script from the same directory with the following command on MacOS or Linux:
+
+```bash
 ./frp.sh -l private.website.local:80 -a "auth_token"
 ```
-Auth token is a token that Qase’s support can provide. In the future, you will be able to specify your Qase API token here.
+
+You can generate authentication token on the [Qase personal settings page](https://app.qase.io/user/api/token).
 
 After running the script, it will create a tunnel to your private website and output the URL to access it. You can use this URL to run cloud tests in Qase.
 
@@ -18,37 +26,5 @@ Run a cloud test run in Qase and specify the created/updated environment.
 You can also specify -t option to specify tunnel name. It should be unique. If you don't specify it, the script will generate a random name.
 
 ## Manual configuration
-1. Install FRP client.
-   - MacOS: `brew install frpc`
-   - For other platforms, download the binary [here](https://github.com/fatedier/frp/releases) and specify its path in your `PATH` environment variable. It will allow you to run it from anywhere
-2. Create a config file `frpc.toml` in any suitable directory
 
-    ```toml
-    serverAddr = "frps.qase.io"
-    serverPort = 7002
-    auth.method = "token"
-    auth.token = "${auth_token}"
-    transport.poolCount = 50
-    transport.protocol = "quic"
-    udpPacketSize = 1500
-    transport.tls.enable = false
-    
-    [[proxies]]
-    name = "${project_name}"
-    type = "http"
-    localIP = "${local_ip}"
-    localPort = ${local_port}
-    subdomain = "${project_name}"
-    hostHeaderRewrite = "${project_host}"
-    ```
-
-3. Replace values:
-   - `${auth_token}` - auth token, Qase’s support can provide a token. In the future, you will be able to specify your Qase API token here
-   - `${project_name}` - project name, it should be unique.
-   you can generate something unique with the command `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1`
-   - `${local_ip}` - local IP of your private website. You can get it with `ping` command
-   - `${local_port}` - local port of your private website, usually 80
-   - `${project_host}` - original hostname for your private website. It should be specified, for the correct working of a private website
-4. Run `frpc -c frpc.toml` in the directory with created `frpc.toml`
-5. Create a new environment or update the existing one in your Qase project. Specify  `http://${project_name}.srv.frps.qase.dev`  as **Host** in the environment
-6. Run a cloud test run in Qase and specify the created/updated environment
+Step for manual configuration are available [here](doc/manual.md).

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1,0 +1,39 @@
+# Manual configuration
+
+1. Install FRP client.
+   - MacOS: `brew install frpc`
+   - For other platforms, download the binary [here](https://github.com/fatedier/frp/releases) and specify its path in your `PATH` environment variable. It will allow you to run it from anywhere
+
+2. Create a config file `frpc.toml` in any suitable directory
+
+    ```toml
+    serverAddr = "frps.qase.io"
+    serverPort = 7002
+    metadatas.token = "<auth_token>"
+    transport.poolCount = 50
+    transport.protocol = "quic"
+    transport.tls.enable = false
+    udpPacketSize = 1500
+    
+    [[proxies]]
+    name = "<project_name>"
+    type = "http"
+    localIP = "<local_ip>"
+    localPort = 80
+    subdomain = "${project_name}"
+    hostHeaderRewrite = "${project_host}"
+    ```
+
+3. Replace values:
+   - `${auth_token}` - auth token, Qase’s support can provide a token. In the future, you will be able to specify your Qase API token here
+   - `${project_name}` - project name, it should be unique.
+     you can generate something unique with the command `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1`
+   - `${local_ip}` - local IP of your private website. You can get it with `ping` command
+   - `${local_port}` - local port of your private website, usually 80
+   - `${project_host}` - original hostname for your private website. It should be specified, for the correct working of a private website
+
+4. Run `frpc -c frpc.toml` in the directory with created `frpc.toml`
+
+5. Create a new environment or update the existing one in your Qase project. Specify  `http://${project_name}.srv.frps.qase.dev`  as **Host** in the environment
+
+6. Run a cloud test run in Qase and specify the created/updated environment

--- a/frp.sh
+++ b/frp.sh
@@ -104,8 +104,7 @@ write_fprc_config() {
     cat > frpc.toml <<EOF
 serverAddr = "${FRP_SERVER}"
 serverPort = 7002
-auth.method = "token"
-auth.token = "${auth_token}"
+metadatas.token = "${auth_token}"
 transport.poolCount = 50
 transport.protocol = "quic"
 udpPacketSize = 1500
@@ -134,7 +133,7 @@ ensure_frpc
 if [[ -z "$auth_token" ]]; then
   if [[ -f "frpc.toml" ]]; then
     # Fetch current auth token from frpc.toml
-    auth_token=$(grep 'auth.token' frpc.toml | sed -E 's/.*auth\.token *= *"([^"]+)".*/\1/')
+    auth_token=$(grep 'metadatas.token' frpc.toml | sed -E 's/.*auth\.token *= *"([^"]+)".*/\1/')
   else
     if [[ -z "$auth_token" ]]; then
       read -p "Enter your authentication token: " auth_token


### PR DESCRIPTION
This pull request includes changes to improve the documentation and configuration process for creating a tunnel to a private website for cloud testing in Qase. The most important changes involve updates to the `README.md` and the addition of a new manual configuration guide.

Configuration updates:

* [`frp.sh`](diffhunk://#diff-01a2574072a8a3d6bb7ca32ce180532796b36d3f0a88302821fc9872dfb3700dL107-R107): Updated the configuration file generation to use `metadatas.token` instead of `auth.token`.
* [`frp.sh`](diffhunk://#diff-01a2574072a8a3d6bb7ca32ce180532796b36d3f0a88302821fc9872dfb3700dL137-R136): Modified the script to fetch the authentication token from `metadatas.token` instead of `auth.token` if the token is not provided.